### PR TITLE
refactor: fix implode deprecations

### DIFF
--- a/admin/systems/services/imap/class_goImapServer.inc
+++ b/admin/systems/services/imap/class_goImapServer.inc
@@ -1,5 +1,7 @@
 <?php
 
+use GosaSystems\admin\systems\services\GoService as goService;
+
 class goImapServer extends goService
 {
 

--- a/admin/systems/services/mail/class_goMailServer.inc
+++ b/admin/systems/services/mail/class_goMailServer.inc
@@ -1,5 +1,7 @@
 <?php
 
+use GosaSystems\admin\systems\services\GoService as goService;
+
 class goMailServer extends goService{
 
     var $cli_summary      = "This pluign is used within the ServerService Pluign \nand indicates that this server supports mailqueue listings and so on.";

--- a/admin/systems/services/spam/class_goSpamServer.inc
+++ b/admin/systems/services/spam/class_goSpamServer.inc
@@ -1,5 +1,7 @@
 <?php
 
+use GosaSystems\admin\systems\services\GoService as goService;
+
 class gospamserver extends goService
 {
 

--- a/admin/systems/services/virus/class_goVirusServer.inc
+++ b/admin/systems/services/virus/class_goVirusServer.inc
@@ -1,5 +1,7 @@
 <?php
 
+use GosaSystems\admin\systems\services\GoService as goService;
+
 class govirusserver extends goService
 {
 

--- a/personal/mail/class_mail-methods-cyrus.inc
+++ b/personal/mail/class_mail-methods-cyrus.inc
@@ -439,7 +439,7 @@ class mailMethodCyrus extends mailMethod
                 __LINE__,
                 __FUNCTION__,
                 __FILE__,
-                trim(implode($result, ", "), ", "),
+                trim(implode(", ", $result), ", "),
                 "<b>IMAP: Received mailbox folders.</b>"
             );
             $this->error = imap_last_error();
@@ -592,7 +592,7 @@ class mailMethodCyrus extends mailMethod
             }
         }
         if (count($files)) {
-            $msg = sprintf(_("File '%s' does not exist!"), implode($files, ", "));
+            $msg = sprintf(_("File '%s' does not exist!"), implode(", ", $files));
             $msg .= "&nbsp;" . _("The sieve script may not be written correctly.");
             msg_dialog::display(_("Warning"), $msg, WARNING_DIALOG);
         }

--- a/personal/mail/class_mail-methods.inc
+++ b/personal/mail/class_mail-methods.inc
@@ -72,6 +72,8 @@ class mailMethod
     protected $connected          = FALSE;
     protected $error              = "";
     protected $parent             = NULL;
+
+    protected $config             = NULL;
     protected $MailServer         = "";
 
     protected $default_acls = array("__anyone__" => "p", "__member__" => "lrswp");
@@ -237,8 +239,8 @@ class mailMethod
             $this->parent->attrs['gosaSharedFolderTarget'] = array();
         }
         foreach ($this->attributes as $source => $dest) {
-            $this->attrs[$dest]   = array();
-            $this->attrs[$source] = array();
+            $this->parent->attrs[$dest]   = array();
+            $this->parent->attrs[$source] = array();
         }
     }
 

--- a/personal/mail/class_mailAccount.inc
+++ b/personal/mail/class_mailAccount.inc
@@ -97,6 +97,7 @@ class mailAccount extends plugin
     var $initial_uid    = "";
     var $mailDomainPart = "";
     var $mailDomainParts = array();
+    var $SpamLevels = NULL;
     var $MailBoxes = array("INBOX");
 
     /* Used LDAP attributes && classes */


### PR DESCRIPTION
- Fixed the following deprecation...
https://www.php.net/manual/en/function.implode.php (Passing the separator after the array (i.e. using the legacy signature) has been deprecated.)

- Adapted/Fix GosaSystems imports to new composer structure